### PR TITLE
Fix convertToPHPValue return types

### DIFF
--- a/src/Carbon/Doctrine/DateTimeImmutableType.php
+++ b/src/Carbon/Doctrine/DateTimeImmutableType.php
@@ -17,7 +17,7 @@ class DateTimeImmutableType extends VarDateTimeImmutableType implements CarbonDo
     /**
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeImmutable
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?CarbonImmutable
     {
         return $this->doConvertToPHPValue($value);
     }

--- a/src/Carbon/Doctrine/DateTimeType.php
+++ b/src/Carbon/Doctrine/DateTimeType.php
@@ -17,7 +17,7 @@ class DateTimeType extends VarDateTimeType implements CarbonDoctrineType
     /**
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTime
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?Carbon
     {
         return $this->doConvertToPHPValue($value);
     }


### PR DESCRIPTION
This is to fix false positive errors reported by phpstan-doctrine which reads these return types:

> `Property MyEntity::$validCarbon type mapping mismatch: database can contain DateTime but property expects Carbon\Carbon.`